### PR TITLE
Fix recovery detection of RAID arrays on debian systems

### DIFF
--- a/plugins/mdstatus/class.mdstatus.inc.php
+++ b/plugins/mdstatus/class.mdstatus.inc.php
@@ -146,7 +146,7 @@ class MDStatus extends PSI_Plugin
                     $this->_result['devices'][$dev]['registered'] = -1;
                     $this->_result['devices'][$dev]['active'] = -1;
                 }
-                if (preg_match(('/([a-z]+)([ ]?)=([ ]?)([0-9\.]+)%/'), $this->_filecontent[$count + 1], $res) || (preg_match(('/([a-z]+)([ ]?)=([ ]?)([0-9\.]+)/'), $optionline, $res))) {
+                if (preg_match(('/([a-z]+)( *)=( *)([0-9.]+)%/'), $this->_filecontent[$count + 1], $res) || (preg_match(('/([a-z]+)( *)=( *)([0-9\.]+)/'), $optionline, $res))) {
                     list($this->_result['devices'][$dev]['action']['name'], $this->_result['devices'][$dev]['action']['percent']) = preg_split("/=/", str_replace("%", "", $res[0]));
                     if (preg_match(('/([a-z]*=[0-9\.]+[a-z]+)/'), $this->_filecontent[$count + 1], $res)) {
                         $time = preg_split("/=/", $res[0]);

--- a/plugins/mdstatus/js/mdstatus.js
+++ b/plugins/mdstatus/js/mdstatus.js
@@ -78,7 +78,7 @@ function mdstatus_buildaction(xml) {
         if (parseInt(name, 10) !== -1) {
             time = $(this).attr("Time_To_Finish");
             tunit = $(this).attr("Time_Unit");
-            percent = parseInt($(this).attr("Percent"), 10);
+            percent = parseFloat($(this).attr("Percent"));
             html += "<div style=\"padding-left:10px;\">";
             html += genlang(13, false, "MDStatus") + ":&nbsp;" + name + "<br/>";
             html += createBar(percent);


### PR DESCRIPTION
- If percent is below 10% there are 2 spaces between "recovery =" and the digits
- Show percent "as is" with decimal dot.

![image](https://f.cloud.github.com/assets/327396/718248/964b26d8-df60-11e2-8a0c-beb7a5adc8b9.png)
