### PR TITLE
Ksplice support for Linux

### DIFF
--- a/includes/os/class.Linux.inc.php
+++ b/includes/os/class.Linux.inc.php
@@ -80,7 +80,7 @@ class Linux extends OS
     private function _kernel()
     {
         // show effective kernel if ksplice uptrack is installed
-        exec('which uptrack-uname > /dev/null 2>1&', $output, $exitcode); // use exit code of which to determine
+        exec('which uptrack-uname > /dev/null 2>&1', $output, $exitcode); // use exit code of which to determine
         if ($exitcode == 0 ) {
             $uname="uptrack-uname";
         } else {


### PR DESCRIPTION
**Adding Ksplice support for Ubuntu, Fedora and Oracle Linux**

phpsysinfo uses `uname` to gather kernel information, which **ONLY** shows the original kernel, it does NOT reflect the **effective kernel** running patched by Ksplice uptrack.

> NOTE: Ksplice is free for Ubuntu and Fedora.

For example:

```
$ uname -a
Linux hostname 3.2.0-23-virtual #36-Ubuntu SMP Tue Apr 10 22:29:03 UTC 2012 x86_64 x86_64 x86_64 GNU/Linux
$ uptrack-uname -a
Linux hostname 3.2.0-51-virtual #77-Ubuntu SMP Wed Jul 24 20:38:32 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux
terry@terry:~$ 
```

`3.2.0-23-virtual` is the original kernel for Ubuntu 12.04 LTS virtual machine. `3.2.0-51-virtual` is the real effective running kernel patched by Ksplice uptrack (simply run `uptrack-upgrade -y` without rebooting).

This is my first PHP patch, forgive my poor coding style;-)

Special thanks to @dongsheng who helped to figure out why `/etc/uptrack/uptrack.conf` won't work. Web server run user (e.g. `www-data`) does **NOT** have permission to the directory `0750` and file `0640` so it always returns false when checking.
