### PR TITLE
Fixed mistake in .htaccess and Linux IP retrieval improvement

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -6,6 +6,6 @@
     </IfModule>
 # Deny all requests from Apache 2.4+
     <IfModule mod_authz_core.c>
-        Require all granted
+        Require all denied
     </IfModule>
 </files>

--- a/includes/os/class.Linux.inc.php
+++ b/includes/os/class.Linux.inc.php
@@ -585,7 +585,18 @@ class Linux extends OS
                     $dev->setTxBytes($stats[8]);
                     $dev->setErrors($stats[2] + $stats[10]);
                     $dev->setDrops($stats[3] + $stats[11]);
-                    if (defined('PSI_SHOW_NETWORK_INFOS') && (PSI_SHOW_NETWORK_INFOS) && (CommonFunctions::executeProgram('ifconfig', trim($dev_name).' 2>/dev/null', $bufr2, PSI_DEBUG))) {
+                    if (defined('PSI_SHOW_NETWORK_INFOS') && (PSI_SHOW_NETWORK_INFOS) && (CommonFunctions::executeProgram('ip', '-s addr show dev ' . trim($dev_name).' 2>/dev/null', $bufr2, PSI_DEBUG))) {
+                        $bufe2 = preg_split("/\n/", $bufr2, -1, PREG_SPLIT_NO_EMPTY);
+                        foreach ($bufe2 as $buf2) {
+                            if (preg_match('/^\s+link\/ether\s(\S+)/i', $buf2, $ar_buf2)) {
+                                $dev->setInfo(($dev->getInfo()?$dev->getInfo().';':'').preg_replace('/:/', '-', $ar_buf2[1]));
+                            }
+                            elseif (preg_match('/^\s+inet6?\s(\S+)\/\d/i', $buf2, $ar_buf2)) {
+                                $dev->setInfo(($dev->getInfo()?$dev->getInfo().';':'').$ar_buf2[1]);
+                            }
+                        }
+                    }
+                    elseif (defined('PSI_SHOW_NETWORK_INFOS') && (PSI_SHOW_NETWORK_INFOS) && (CommonFunctions::executeProgram('ifconfig', trim($dev_name).' 2>/dev/null', $bufr2, PSI_DEBUG))) {
                         $bufe2 = preg_split("/\n/", $bufr2, -1, PREG_SPLIT_NO_EMPTY);
                         foreach ($bufe2 as $buf2) {
 //                            if (preg_match('/^'.trim($dev_name).'\s+Link\sencap:Ethernet\s+HWaddr\s(\S+)/i', $buf2, $ar_buf2)


### PR DESCRIPTION
Fix mistake in .htaccess for securing phpsysinfo.ini per http://httpd.apache.org/docs/2.4/upgrading.html#access

Rewrote Linux network link code to use iproute2 in preference to net-tools so it retrieves all available IPv4/6 addresses, not just the ones ifconfig can see.