### PR TITLE
add missing semicolon in default setting ini

### DIFF
--- a/phpsysinfo.ini.new
+++ b/phpsysinfo.ini.new
@@ -490,7 +490,7 @@ ACCESS="command"
 ; define how to access the battery statistic data
 ; - "command" on Linux and Android read data from /proc/acpi/battery/BAT0/info and /proc/acpi/battery/BAT0/state
 ;                or on newer kernel from /sys/class/power_supply/
-                 or from 'upower -d' command (if UPOWER is true)
+;                or from 'upower -d' command (if UPOWER is true)
 ;             on Android read data from /sys/class/power_supply/ 
 ;             on Darwin read data from 'ioreg -w0 -l -n AppleSmartBattery -r' command
 ;             on FreeBSD read data from 'acpiconf -i batt' command


### PR DESCRIPTION
this could cause ini parsing error, and makes system think there's no ini file