### PR TITLE
Improve uprecords plugin output

### DIFF
--- a/plugins/uprecords/class.uprecords.inc.php
+++ b/plugins/uprecords/class.uprecords.inc.php
@@ -72,7 +72,7 @@ class uprecords extends PSI_Plugin
                         $options=" -m ".PSI_PLUGIN_UPRECORDS_MAX_ENTRIES;
                     }
                 }
-                if (CommonFunctions::executeProgram('TZ=GMT uprecords', '-a -w'.$options, $lines) && !empty($lines))
+                if (CommonFunctions::executeProgram('TZ=GMT uprecords', '-a -w -s'.$options, $lines) && !empty($lines))
                     $this->_lines = preg_split("/\n/", $lines, -1, PREG_SPLIT_NO_EMPTY);
                 break;
             case 'data':

--- a/plugins/uprecords/class.uprecords.inc.php
+++ b/plugins/uprecords/class.uprecords.inc.php
@@ -37,7 +37,7 @@ class uprecords extends PSI_Plugin
             if (($i > 1) and (strpos($line, '---') === false)) {
                 $buffer = preg_split("/\s*[ |]\s+/", ltrim(ltrim($line, '->'), ' '));
                 if (strpos($line, '->') !== false) {
-                    $buffer[0] = '-> '.$buffer[0];
+                    $buffer[0] = $buffer[0].' *';
                 }
 
                 if (count($buffer) > 4) {


### PR DESCRIPTION
Removes the 'extra statistics' from the output by passing `-s` to `uprecords` - the plugin does not appear to support parsing these rows correctly.

Minor change to the row highlighting the current uptime so that it no longer causes the record number to be misaligned.

I'm testing this against uprecords 0.4.0 on Ubuntu 18.10.