### PR TITLE
Add UPS beeper status support, complete Czech translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 phpsysinfo.ini
 composer.lock
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 phpsysinfo.ini
 composer.lock
+.idea/

--- a/includes/to/class.UPSInfo.inc.php
+++ b/includes/to/class.UPSInfo.inc.php
@@ -39,7 +39,7 @@ class UPSInfo
      *
      * @see UPSInfo::$_upsDevices
      *
-     * @return array|UPSDevice[]
+     * @return array
      */
     public function getUpsDevices()
     {

--- a/includes/to/class.UPSInfo.inc.php
+++ b/includes/to/class.UPSInfo.inc.php
@@ -39,7 +39,7 @@ class UPSInfo
      *
      * @see UPSInfo::$_upsDevices
      *
-     * @return array
+     * @return array|UPSDevice[]
      */
     public function getUpsDevices()
     {

--- a/includes/to/device/class.UPSDevice.inc.php
+++ b/includes/to/device/class.UPSDevice.inc.php
@@ -138,6 +138,13 @@ class UPSDevice
     private $_timeLeft = null;
 
     /**
+     * beeper enabled or disabled
+     *
+     * @var String
+     */
+    private $_beeperStatus = null;
+
+    /**
      * Returns $_batterCharge.
      *
      * @see UPSDevice::$_batterCharge
@@ -551,5 +558,31 @@ class UPSDevice
     public function setTimeLeft($timeLeft)
     {
         $this->_timeLeft = $timeLeft;
+    }
+
+    /**
+     * Returns $_beeperStatus.
+     *
+     * @see UPSDevice::$_beeperStatus
+     *
+     * @return String
+     */
+    public function getBeeperStatus()
+    {
+        return $this->_beeperStatus;
+    }
+
+    /**
+     * Sets $_beeperStatus.
+     *
+     * @param String $beeperStatus beeper status
+     *
+     * @see UPSDevice::$_beeperStatus
+     *
+     * @return Void
+     */
+    public function setBeeperStatus($beeperStatus)
+    {
+        $this->_beeperStatus = $beeperStatus;
     }
 }

--- a/includes/ups/class.nut.inc.php
+++ b/includes/ups/class.nut.inc.php
@@ -128,6 +128,9 @@ class Nut extends UPS
                 if (isset($ups_data['ups.status'])) {
                     $dev->setStatus($ups_data['ups.status']);
                 }
+                if (isset($ups_data['ups.beeper.status'])) {
+                    $dev->setBeeperStatus($ups_data['ups.beeper.status']);
+                }
 
                 //Line
                 if (isset($ups_data['input.voltage'])) {

--- a/includes/xml/class.XML.inc.php
+++ b/includes/xml/class.XML.inc.php
@@ -698,6 +698,7 @@ class XML
         }
         if (sizeof(unserialize(PSI_UPSINFO))>0) {
             foreach (unserialize(PSI_UPSINFO) as $upsinfoclass) {
+                /** @var PSI_Interface_UPS $upsinfo_data */
                 $upsinfo_data = new $upsinfoclass();
                 $upsinfo_detail = $upsinfo_data->getUPSInfo();
                 foreach ($upsinfo_detail->getUpsDevices() as $ups) {
@@ -713,6 +714,9 @@ class XML
                         $item->addAttribute('StartTime', $ups->getStartTime());
                     }
                     $item->addAttribute('Status', $ups->getStatus());
+                    if ($ups->getBeeperStatus() !== null) {
+                        $item->addAttribute('BeeperStatus', $ups->getBeeperStatus());
+                    }
                     if ($ups->getTemperatur() !== null) {
                         $item->addAttribute('Temperature', $ups->getTemperatur());
                     }

--- a/includes/xml/class.XML.inc.php
+++ b/includes/xml/class.XML.inc.php
@@ -698,7 +698,6 @@ class XML
         }
         if (sizeof(unserialize(PSI_UPSINFO))>0) {
             foreach (unserialize(PSI_UPSINFO) as $upsinfoclass) {
-                /** @var PSI_Interface_UPS $upsinfo_data */
                 $upsinfo_data = new $upsinfoclass();
                 $upsinfo_detail = $upsinfo_data->getUPSInfo();
                 foreach ($upsinfo_detail->getUpsDevices() as $ups) {

--- a/js/phpSysInfo/phpsysinfo.js
+++ b/js/phpSysInfo/phpsysinfo.js
@@ -1552,12 +1552,13 @@ function refreshUps(xml) {
 
     $("#ups").empty();
     $("UPSInfo UPS", xml).each(function getUps(id) {
-        var name = "", model = "", mode = "", start_time = "", upsstatus = "", temperature = "", outages_count = "", last_outage = "", last_outage_finish = "", line_voltage = "", line_frequency = "", load_percent = "", battery_date = "", battery_voltage = "", battery_charge_percent = "", time_left_minutes = "";
+        var name = "", model = "", mode = "", start_time = "", upsstatus = "", beeperstatus = "", temperature = "", outages_count = "", last_outage = "", last_outage_finish = "", line_voltage = "", line_frequency = "", load_percent = "", battery_date = "", battery_voltage = "", battery_charge_percent = "", time_left_minutes = "";
         name = $(this).attr("Name");
         model = $(this).attr("Model");
         mode = $(this).attr("Mode");
         start_time = $(this).attr("StartTime");
         upsstatus = $(this).attr("Status");
+        beeperstatus = $(this).attr("BeeperStatus");
 
         temperature = $(this).attr("Temperature");
         outages_count = $(this).attr("OutagesCount");
@@ -1587,6 +1588,10 @@ function refreshUps(xml) {
         }
         if (upsstatus !== undefined) {
             html += "<tr><td style=\"width:36%\"><div class=\"treediv\"><span class=\"treespan\">" + genlang(73) + "</span></div></td><td>" + upsstatus + "</td></tr>\n";
+            tree.push(index);
+        }
+        if (beeperstatus !== undefined) {
+            html += "<tr><td style=\"width:36%\"><div class=\"treediv\"><span class=\"treespan\">" + genlang(133) + "</span></div></td><td>" + beeperstatus + "</td></tr>\n";
             tree.push(index);
         }
         if (temperature !== undefined) {

--- a/js/phpSysInfo/phpsysinfo_bootstrap.js
+++ b/js/phpSysInfo/phpsysinfo_bootstrap.js
@@ -1598,7 +1598,7 @@ function renderUPS(data) {
 
     if ((data.UPSInfo !== undefined) && (items(data.UPSInfo.UPS).length > 0)) {
         var html="";
-        var paramlist = {Model:70,StartTime:72,Status:73,Temperature:84,OutagesCount:74,LastOutage:75,LastOutageFinish:76,LineVoltage:77,LineFrequency:108,LoadPercent:78,BatteryDate:104,BatteryVoltage:79,BatteryChargePercent:80,TimeLeftMinutes:81};
+        var paramlist = {Model:70,StartTime:72,Status:73,BeeperStatus:133,Temperature:84,OutagesCount:74,LastOutage:75,LastOutageFinish:76,LineVoltage:77,LineFrequency:108,LoadPercent:78,BatteryDate:104,BatteryVoltage:79,BatteryChargePercent:80,TimeLeftMinutes:81};
 
         try {
             datas = items(data.UPSInfo.UPS);

--- a/language/ar.xml
+++ b/language/ar.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Arabic Created by: yshalsager
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/ast.xml
+++ b/language/ast.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Asturian Created by: Mikel González
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/bg.xml
+++ b/language/bg.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Bulgarian Created by: Grigor Josifov
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/ca.xml
+++ b/language/ca.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Catalan Created by: Axel Arbones #LittleBerry
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/cz.xml
+++ b/language/cz.xml
@@ -136,7 +136,7 @@ phpSysInfo language file Language: Czech Created by: Peter 'Pessoft' Kolínek
     <exp>Kapacita</exp>
   </expression>
   <expression id="044" name="template">
-    <exp>Téma vzhledu</exp>
+    <exp>Šablona vzhledu</exp>
   </expression>
   <expression id="045" name="language">
     <exp>Jazyk</exp>
@@ -295,31 +295,31 @@ phpSysInfo language file Language: Czech Created by: Peter 'Pessoft' Kolínek
     <exp>B</exp>
   </expression>
   <expression id="097" name="syslang">
-    <exp>System Language</exp>
+    <exp>Systémový jazyk</exp>
   </expression>
   <expression id="098" name="codepage">
-    <exp>Code Page</exp>
+    <exp>Znaková stránka</exp>
   </expression>
   <expression id="099" name="details">
-    <exp>Details</exp>
+    <exp>Podrobnosti</exp>
   </expression>
   <expression id="100" name="cpuspeedMax">
-    <exp>CPU Speed Max</exp>
+    <exp>Nejvyšší frekvence CPU</exp>
   </expression>
   <expression id="101" name="cpuspeedMin">
-    <exp>CPU Speed Min</exp>
+    <exp>Nejnižší frekvence CPU</exp>
   </expression>
   <expression id="102" name="power">
-    <exp>Power</exp>
+    <exp>Výkon</exp>
   </expression>
   <expression id="103" name="power_mark">
     <exp>W</exp>
   </expression>
   <expression id="104" name="ups_battery_date">
-    <exp>Battery date</exp>
+    <exp>Datum baterie</exp>
   </expression>
   <expression id="105" name="current">
-    <exp>Current</exp>
+    <exp>Proud</exp>
   </expression>
   <expression id="106" name="current_mark">
     <exp>A</exp>
@@ -328,31 +328,31 @@ phpSysInfo language file Language: Czech Created by: Peter 'Pessoft' Kolínek
     <exp>Machine</exp>
   </expression>
   <expression id="108" name="ups_line_frequency">
-    <exp>Line frequency</exp>
+    <exp>Frekvence sítě</exp>
   </expression>
   <expression id="109" name="Hz">
     <exp>Hz</exp>
   </expression>
   <expression id="110" name="Processes">
-    <exp>Processes</exp>
+    <exp>Procesy</exp>
   </expression>
   <expression id="111" name="ProcessesRunning">
-    <exp>running</exp>
+    <exp>aktivní</exp>
   </expression>
   <expression id="112" name="ProcessesSleeping">
-    <exp>sleeping</exp>
+    <exp>neaktivní</exp>
   </expression>
   <expression id="113" name="ProcessesStopped">
-    <exp>stopped</exp>
+    <exp>zastavené</exp>
   </expression>
   <expression id="114" name="ProcessesZombie">
     <exp>zombie</exp>
   </expression>
   <expression id="115" name="ProcessesWaiting">
-    <exp>waiting</exp>
+    <exp>čekající</exp>
   </expression>
   <expression id="116" name="ProcessesOther">
-    <exp>other</exp>
+    <exp>ostatní</exp>
   </expression>
   <expression id="117" name="tb">
     <exp>TB zařízení</exp>
@@ -361,22 +361,22 @@ phpSysInfo language file Language: Czech Created by: Peter 'Pessoft' Kolínek
     <exp>I2C zařízení</exp>
   </expression>
   <expression id="119" name="no_processors">
-    <exp>Number of processors</exp>
+    <exp>Počet procesorů</exp>
   </expression>
   <expression id="120" name="no_devices">
-    <exp>Number of devices</exp>
+    <exp>Počet zařízení</exp>
   </expression>
   <expression id="121" name="other">
-    <exp>Other</exp>
+    <exp>Ostatní</exp>
   </expression>
   <expression id="122" name="manufacturer">
-    <exp>Manufacturer</exp>
+    <exp>Výrobce</exp>
   </expression>
   <expression id="123" name="product">
-    <exp>Product</exp>
+    <exp>Produkt</exp>
   </expression>
   <expression id="124" name="serial">
-    <exp>Serial number</exp>
+    <exp>Sériové číslo</exp>
   </expression>
   <expression id="125" name="memfree">
     <exp>Volné</exp>
@@ -385,21 +385,24 @@ phpSysInfo language file Language: Czech Created by: Peter 'Pessoft' Kolínek
     <exp>NVMe zařízení</exp>
   </expression>
   <expression id="127" name="os">
-    <exp>OS Type</exp>
+    <exp>Typ OS</exp>
   </expression>
   <expression id="128" name="no_memories">
-    <exp>Number of memory chips</exp>
+    <exp>Počet paměťových čipů</exp>
   </expression>
   <expression id="129" name="speed">
-    <exp>Speed</exp>
+    <exp>Rychlost</exp>
   </expression>
   <expression id="130" name="mem">
-    <exp>Memory Chips</exp>
+    <exp>Paměťové čipy</exp>
   </expression>
   <expression id="131" name="mtps">
     <exp>MT/s</exp>
   </expression>
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
+  </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Stav pípáku</exp>
   </expression>
 </tns:translation>

--- a/language/cz.xml
+++ b/language/cz.xml
@@ -325,7 +325,7 @@ phpSysInfo language file Language: Czech Created by: Peter 'Pessoft' Kolínek
     <exp>A</exp>
   </expression>
   <expression id="107" name="machine">
-    <exp>Machine</exp>
+    <exp>Zařízení</exp>
   </expression>
   <expression id="108" name="ups_line_frequency">
     <exp>Frekvence sítě</exp>

--- a/language/da.xml
+++ b/language/da.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Dansk Created by: Jens F. O. Pedersen
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/de.xml
+++ b/language/de.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: German Created by: Michael Cramer Modified by
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/en.xml
+++ b/language/en.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: English Created by: Audun Larsen
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/es.xml
+++ b/language/es.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Spanish Created by: J.F. Ruano
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/et.xml
+++ b/language/et.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Estoanian Created by: Harg
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/fa.xml
+++ b/language/fa.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Persian Created by: Milad Abooali
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/fi.xml
+++ b/language/fi.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Finnish Created by: nakeman
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/fr.xml
+++ b/language/fr.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: French Created by: Cyril Servant
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/gl.xml
+++ b/language/gl.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: galician Created by: X.M.C. Guede
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/gr.xml
+++ b/language/gr.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Greek Created by: mojiro
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/he.xml
+++ b/language/he.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Hebrew translated by: Eliezer Croitoru
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/hr.xml
+++ b/language/hr.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Croatian Created by: Martin Sajda
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/hu.xml
+++ b/language/hu.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Hungarian Created by: Bálint Kiss
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/id.xml
+++ b/language/id.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Indonesian Created by: RegalChivas
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/is.xml
+++ b/language/is.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Icelandic Created by: Saevar Holm and Kristja
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/it.xml
+++ b/language/it.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Italian Created by: Dario Pilori
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/ja.xml
+++ b/language/ja.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Japanese Created by: nrgmilk
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/ko.xml
+++ b/language/ko.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Korean Created by: Darkcycle, Kang Bundo, SD 
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/nl.xml
+++ b/language/nl.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Dutch Created by: Jaap Struyk
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/no.xml
+++ b/language/no.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Norwegian Created by: Audun Larsen
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/pl.xml
+++ b/language/pl.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Polish Created by: Damian Pasternok
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/pt-br.xml
+++ b/language/pt-br.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Brazilian Portuguese Created by: Giancarlo Gi
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/pt-pt.xml
+++ b/language/pt-pt.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Portuguese Created by:Rui Rebelo
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/ro.xml
+++ b/language/ro.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Romană Created by: Sorin Gheorghe Update by:
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/ru.xml
+++ b/language/ru.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Russian Created by: Max Shchuplov Updated by:
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/sk.xml
+++ b/language/sk.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Slovak Created by: Peter 'Pessoft' Kolínek
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/sl.xml
+++ b/language/sl.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Slovene Created by: Dejan Strancar Maintained
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/sv.xml
+++ b/language/sv.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Svenska Created by: Martin Axelsson
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/th.xml
+++ b/language/th.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Thai Created by: Audun Larsen
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/tr.xml
+++ b/language/tr.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Turkish Created by: Kamil Sarıaydın Updated
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/tw.xml
+++ b/language/tw.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Chinese Traditional Created by: capriskye::an
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/uk.xml
+++ b/language/uk.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Ukrainian Created by: Artem Volk
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/language/zh.xml
+++ b/language/zh.xml
@@ -402,4 +402,7 @@ phpSysInfo language file Language: Simplified Chinese Created by: AlloVince allo
   <expression id="132" name="gtps">
     <exp>GT/s</exp>
   </expression>
+  <expression id="133" name="ups_beeper_status">
+    <exp>Beeper status</exp>
+  </expression>
 </tns:translation>

--- a/phpsysinfo3.xsd
+++ b/phpsysinfo3.xsd
@@ -448,6 +448,7 @@
         <attribute name="Mode" type="string" use="required"></attribute>
         <attribute name="StartTime" type="string" use="optional"></attribute>
         <attribute name="Status" type="string" use="required"></attribute>
+        <attribute name="BeeperStatus" type="string" use="optional"></attribute>
         <attribute name="Temperature" type="unsignedLong" use="optional"></attribute>
         <attribute name="OutagesCount" type="unsignedLong" use="optional"></attribute>
         <attribute name="LastOutage" type="string" use="optional"></attribute>

--- a/plugins/pingtest/lang/cz.xml
+++ b/plugins/pingtest/lang/cz.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+phpSysInfo language file Language: Czech Created by: Ashus
+-->
+<tns:translationPlugin language="czech" charset="utf-8"
+ xmlns:tns="http://phpsysinfo.sourceforge.net/translation-plugin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://phpsysinfo.sourceforge.net/translation-plugin ../../../language/translation-plugin.xsd">
+  <expression id="plugin_pingtest_001" name="pingtest_title">
+    <exp>Ping</exp>
+  </expression>
+  <expression id="plugin_pingtest_002" name="pingtest_address">
+    <exp>Adresa</exp>
+  </expression>
+  <expression id="plugin_pingtest_003" name="pingtest_pingtime">
+    <exp>Odezva</exp>
+  </expression>
+  <expression id="plugin_pingtest_004" name="pingtest_lost">
+    <exp>ztráta</exp>
+  </expression>
+</tns:translationPlugin>


### PR DESCRIPTION
I've added a support for displaying whether the UPS alarm beeper is enabled or not. Though you cannot change it via phpsysinfo, you might want to know, which UPS makes loud alarm when AC becomes offline.
Also I completed new lines of Czech translation, so it is complete again.