### PR TITLE
update dockerfile - bump ubuntu variant, move to php7.4, try and use …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,28 @@
 # phpSysInfo
 # VERSION       3
 
-FROM ubuntu:16.04
+FROM ubuntu:20.04
+ENV LC_ALL C.UTF-8
+ARG DEBIAN_FRONTEND=noninteractive
+ARG http_proxy=""
+ARG https_proxy=""
+
 #FROM ubuntu:14.04
 
 MAINTAINER phpSysInfo
 
 # Update sources
 #RUN echo "deb http://archive.ubuntu.com/ubuntu trusty main universe" > /etc/apt/sources.list
-RUN apt-get update
+RUN apt-get -q update && \
+    apt-get -qy install apache2 php7.4 php7.4-xml php7.4-mbstring libapache2-mod-php7.4 git pciutils && \
+    apt-get clean && \
+    rm -Rf /var/lib/apt/lists/*
 
-RUN apt-get install -y apache2 php7.0 php7.0-xml php7.0-mbstring libapache2-mod-php7.0 git pciutils
-#RUN apt-get install -y apache2 php5 git pciutils
-
-RUN git clone https://github.com/phpsysinfo/phpsysinfo.git /var/www/html/phpsysinfo
-RUN cp /var/www/html/phpsysinfo/phpsysinfo.ini.new /var/www/html/phpsysinfo/phpsysinfo.ini
+RUN git clone https://github.com/phpsysinfo/phpsysinfo.git /var/www/html/phpsysinfo && \
+    cp /var/www/html/phpsysinfo/phpsysinfo.ini.new /var/www/html/phpsysinfo/phpsysinfo.ini
 #RUN cat /var/www/html/phpsysinfo/phpsysinfo.ini.new | sed 's/^LOAD_BAR=false/LOAD_BAR=true/' >/var/www/html/phpsysinfo/phpsysinfo.ini
 
+ENV APACHE_RUN_DIR /var/run/apache2
 ENV APACHE_RUN_USER www-data
 ENV APACHE_RUN_GROUP www-data
 ENV APACHE_LOG_DIR /var/log/apache2


### PR DESCRIPTION

### Summary ###

Update Docker image to use Ubuntu 20.04 not an ancient variant.
Update PHP version to 7.4 (7.0 is technically not supported by the PHP project).
Rejig the Dockerfile a little to chain some RUN commands together, to reduce the layer count (perhaps).
Better cleanup of apt files after build
Add DEBIAN_FRONTEND=noninteractive to build etc.

### Types of changes ###

n/a

### Code Preparation ###


- [x] Check for unused code
- [x] No unrelated changes are included
- [x] None of the changed files are reformatting only
- [x] Code is self explanatory or documented
- [x] All written text is properly translated (english language) (n/a)
