### PR TITLE
phpdoc improvements

### DIFF
--- a/includes/class.CommonFunctions.inc.php
+++ b/includes/class.CommonFunctions.inc.php
@@ -28,7 +28,7 @@ class CommonFunctions
     /**
      * holds codepage for chcp
      *
-     * @var integer
+     * @var int
      */
     private static $_cp = null;
 
@@ -195,7 +195,7 @@ class CommonFunctions
      * @param string  $strArgs        arguments to the program
      * @param string  &$strBuffer     output of the command
      * @param boolean $booErrorRep    en- or disables the reporting of errors which should be logged
-     * @param integer $timeout        timeout value in seconds (default value is PSI_EXEC_TIMEOUT_INT)
+     * @param int $timeout        timeout value in seconds (default value is PSI_EXEC_TIMEOUT_INT)
      *
      * @return boolean command successfull or not
      */
@@ -382,8 +382,8 @@ class CommonFunctions
      *
      * @param string  $strFileName name of the file which should be read
      * @param string  &$strRet     content of the file (reference)
-     * @param integer $intLines    control how many lines should be read
-     * @param integer $intBytes    control how many bytes of each line should be read
+     * @param int $intLines    control how many lines should be read
+     * @param int $intBytes    control how many bytes of each line should be read
      * @param boolean $booErrorRep en- or disables the reporting of errors which should be logged
      *
      * @return boolean command successfull or not
@@ -568,7 +568,7 @@ class CommonFunctions
      * @param array   $pipes   array of file pointers for stdin, stdout, stderr (proc_open())
      * @param string  &$out    target string for the output message (reference)
      * @param string  &$err    target string for the error message (reference)
-     * @param integer $timeout timeout value in seconds
+     * @param int $timeout timeout value in seconds
      *
      * @return boolean timeout expired or not
      */

--- a/includes/mb/class.coretemp.inc.php
+++ b/includes/mb/class.coretemp.inc.php
@@ -21,7 +21,7 @@ class Coretemp extends Hwmon
      *
      * @see PSI_Interface_Sensor::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/mb/class.freeipmi.inc.php
+++ b/includes/mb/class.freeipmi.inc.php
@@ -173,7 +173,7 @@ class FreeIPMI extends Sensors
      *
      * @see PSI_Interface_Sensor::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/mb/class.hddtemp.inc.php
+++ b/includes/mb/class.hddtemp.inc.php
@@ -115,7 +115,7 @@ class HDDTemp extends Sensors
      *
      * @see PSI_Interface_Sensor::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/mb/class.healthd.inc.php
+++ b/includes/mb/class.healthd.inc.php
@@ -146,7 +146,7 @@ class Healthd extends Sensors
      *
      * @see PSI_Interface_Sensor::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/mb/class.hwmon.inc.php
+++ b/includes/mb/class.hwmon.inc.php
@@ -242,7 +242,7 @@ class Hwmon extends Sensors
      *
      * @see PSI_Interface_Sensor::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/mb/class.hwsensors.inc.php
+++ b/includes/mb/class.hwsensors.inc.php
@@ -136,7 +136,7 @@ class HWSensors extends Sensors
      *
      * @see PSI_Interface_Sensor::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/mb/class.ipmicfg.inc.php
+++ b/includes/mb/class.ipmicfg.inc.php
@@ -225,7 +225,7 @@ class IPMIcfg extends Sensors
      *
      * @see PSI_Interface_Sensor::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/mb/class.ipmitool.inc.php
+++ b/includes/mb/class.ipmitool.inc.php
@@ -306,7 +306,7 @@ class IPMItool extends Sensors
      *
      * @see PSI_Interface_Sensor::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/mb/class.ipmiutil.inc.php
+++ b/includes/mb/class.ipmiutil.inc.php
@@ -251,7 +251,7 @@ class IPMIutil extends Sensors
      *
      * @see PSI_Interface_Sensor::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/mb/class.k8temp.inc.php
+++ b/includes/mb/class.k8temp.inc.php
@@ -71,7 +71,7 @@ class K8Temp extends Sensors
      *
      * @see PSI_Interface_Sensor::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/mb/class.lmsensors.inc.php
+++ b/includes/mb/class.lmsensors.inc.php
@@ -405,7 +405,7 @@ class LMSensors extends Sensors
      *
      * @see PSI_Interface_Sensor::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/mb/class.mbm5.inc.php
+++ b/includes/mb/class.mbm5.inc.php
@@ -110,7 +110,7 @@ class MBM5 extends Sensors
      *
      * @see PSI_Interface_Sensor::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/mb/class.nvidiasmi.inc.php
+++ b/includes/mb/class.nvidiasmi.inc.php
@@ -58,7 +58,7 @@ class NvidiaSMI extends Sensors
      *
      * @see PSI_Interface_Sensor::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/mb/class.ohm.inc.php
+++ b/includes/mb/class.ohm.inc.php
@@ -105,7 +105,7 @@ class OHM extends Sensors
      *
      * @see PSI_Interface_Sensor::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/mb/class.qtssnmp.inc.php
+++ b/includes/mb/class.qtssnmp.inc.php
@@ -71,7 +71,7 @@ class QTSsnmp extends Sensors
      *
      * @see PSI_Interface_Sensor::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/mb/class.speedfan.inc.php
+++ b/includes/mb/class.speedfan.inc.php
@@ -115,7 +115,7 @@ class SpeedFan extends Sensors
      *
      * @see PSI_Interface_Sensor::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/mb/class.thermalzone.inc.php
+++ b/includes/mb/class.thermalzone.inc.php
@@ -148,7 +148,7 @@ class ThermalZone extends Sensors
      *
      * @see PSI_Interface_Sensor::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/mb/class.thinkpad.inc.php
+++ b/includes/mb/class.thinkpad.inc.php
@@ -19,7 +19,7 @@ class Thinkpad extends Hwmon
      *
      * @see PSI_Interface_Sensor::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/os/class.AIX.inc.php
+++ b/includes/os/class.AIX.inc.php
@@ -336,7 +336,7 @@ class AIX extends OS
      *
      * @see PSI_Interface_OS::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/os/class.Android.inc.php
+++ b/includes/os/class.Android.inc.php
@@ -241,7 +241,7 @@ class Android extends Linux
      *
      * @see PSI_Interface_OS::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/os/class.BSDCommon.inc.php
+++ b/includes/os/class.BSDCommon.inc.php
@@ -876,7 +876,7 @@ abstract class BSDCommon extends OS
      *
      * @see PSI_Interface_OS::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/os/class.Darwin.inc.php
+++ b/includes/os/class.Darwin.inc.php
@@ -470,7 +470,7 @@ class Darwin extends BSDCommon
      *
      * @see PSI_Interface_OS::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/os/class.DragonFly.inc.php
+++ b/includes/os/class.DragonFly.inc.php
@@ -127,7 +127,7 @@ class DragonFly extends BSDCommon
      *
      * @see BSDCommon::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/os/class.FreeBSD.inc.php
+++ b/includes/os/class.FreeBSD.inc.php
@@ -182,7 +182,7 @@ class FreeBSD extends BSDCommon
      *
      * @see BSDCommon::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/os/class.HPUX.inc.php
+++ b/includes/os/class.HPUX.inc.php
@@ -363,7 +363,7 @@ class HPUX extends OS
      *
      * @see PSI_Interface_OS::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/os/class.Haiku.inc.php
+++ b/includes/os/class.Haiku.inc.php
@@ -368,7 +368,7 @@ class Haiku extends OS
     /**
      * get the information
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/os/class.Linux.inc.php
+++ b/includes/os/class.Linux.inc.php
@@ -508,7 +508,7 @@ class Linux extends OS
      *
      * @param String $cpuline cpu for which load should be meassured
      *
-     * @return Integer
+     * @return int
      */
     protected function _parseProcStat($cpuline)
     {
@@ -2025,7 +2025,7 @@ class Linux extends OS
      *
      * @see PSI_Interface_OS::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/os/class.Minix.inc.php
+++ b/includes/os/class.Minix.inc.php
@@ -333,7 +333,7 @@ class Minix extends OS
     /**
      * get the information
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/os/class.NetBSD.inc.php
+++ b/includes/os/class.NetBSD.inc.php
@@ -250,7 +250,7 @@ class NetBSD extends BSDCommon
      *
      * @see BSDCommon::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/os/class.OpenBSD.inc.php
+++ b/includes/os/class.OpenBSD.inc.php
@@ -250,7 +250,7 @@ class OpenBSD extends BSDCommon
      *
      * @see BSDCommon::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/os/class.QNX.inc.php
+++ b/includes/os/class.QNX.inc.php
@@ -205,7 +205,7 @@ class QNX extends OS
     /**
      * get the information
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/os/class.SunOS.inc.php
+++ b/includes/os/class.SunOS.inc.php
@@ -454,7 +454,7 @@ class SunOS extends OS
      *
      * @see PSI_Interface_OS::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/os/class.WINNT.inc.php
+++ b/includes/os/class.WINNT.inc.php
@@ -1464,7 +1464,7 @@ class WINNT extends OS
      *
      * @see PSI_Interface_OS::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/output/class.Webpage.inc.php
+++ b/includes/output/class.Webpage.inc.php
@@ -28,21 +28,21 @@ class Webpage extends Output implements PSI_Interface_Output
     /**
      * configured indexname
      *
-     * @var String
+     * @var string
      */
     private $_indexname;
 
     /**
      * configured language
      *
-     * @var String
+     * @var string
      */
     private $_language;
 
     /**
      * configured template
      *
-     * @var String
+     * @var string
      */
     private $_template;
 
@@ -56,7 +56,7 @@ class Webpage extends Output implements PSI_Interface_Output
     /**
      * configured bootstrap template
      *
-     * @var String
+     * @var string
      */
     private $_bootstrap_template;
 

--- a/includes/to/class.System.inc.php
+++ b/includes/to/class.System.inc.php
@@ -28,70 +28,70 @@ class System
     /**
      * name of the host where phpSysInfo runs
      *
-     * @var String
+     * @var string
      */
     private $_hostname = "localhost";
 
     /**
      * ip of the host where phpSysInfo runs
      *
-     * @var String
+     * @var string
      */
     private $_ip = "127.0.0.1";
 
     /**
      * detailed information about the kernel
      *
-     * @var String
+     * @var string
      */
     private $_kernel = "Unknown";
 
     /**
      * name of the distribution
      *
-     * @var String
+     * @var string
      */
     private $_distribution = "Unknown";
 
     /**
      * icon of the distribution (must be available in phpSysInfo)
      *
-     * @var String
+     * @var string
      */
     private $_distributionIcon = "unknown.png";
 
     /**
      * detailed Information about the machine name
      *
-     * @var String
+     * @var string
      */
     private $_machine = "";
 
     /**
      * time in sec how long the system is running
      *
-     * @var Integer
+     * @var int
      */
     private $_uptime = 0;
 
     /**
      * count of users that are currently logged in
      *
-     * @var Integer
+     * @var int
      */
     private $_users = 0;
 
     /**
      * load of the system
      *
-     * @var String
+     * @var string
      */
     private $_load = "";
 
     /**
      * load of the system in percent (all cpus, if more than one)
      *
-     * @var Integer
+     * @var int
      */
     private $_loadPercent = null;
 
@@ -197,42 +197,42 @@ class System
     /**
      * free memory in bytes
      *
-     * @var Integer
+     * @var int
      */
     private $_memFree = 0;
 
     /**
      * total memory in bytes
      *
-     * @var Integer
+     * @var int
      */
     private $_memTotal = 0;
 
     /**
      * used memory in bytes
      *
-     * @var Integer
+     * @var int
      */
     private $_memUsed = 0;
 
     /**
      * used memory by applications in bytes
      *
-     * @var Integer
+     * @var int
      */
     private $_memApplication = null;
 
     /**
      * used memory for buffers in bytes
      *
-     * @var Integer
+     * @var int
      */
     private $_memBuffer = null;
 
     /**
      * used memory for cache in bytes
      *
-     * @var Integer
+     * @var int
      */
     private $_memCache = null;
 
@@ -298,7 +298,7 @@ class System
      * @see System::_memUsed
      * @see System::_memTotal
      *
-     * @return Integer
+     * @return int
      */
     public function getMemPercentUsed()
     {
@@ -315,7 +315,7 @@ class System
      * @see System::_memApplication
      * @see System::_memTotal
      *
-     * @return Integer
+     * @return int
      */
     public function getMemPercentApplication()
     {
@@ -336,7 +336,7 @@ class System
      * @see System::_memCache
      * @see System::_memTotal
      *
-     * @return Integer
+     * @return int
      */
     public function getMemPercentCache()
     {
@@ -361,7 +361,7 @@ class System
      * @see System::_memBuffer
      * @see System::_memTotal
      *
-     * @return Integer
+     * @return int
      */
     public function getMemPercentBuffer()
     {
@@ -392,7 +392,7 @@ class System
      * @see System::_swapDevices
      * @see DiskDevice::getFree()
      *
-     * @return Integer
+     * @return int
      */
     public function getSwapFree()
     {
@@ -414,7 +414,7 @@ class System
      * @see System::_swapDevices
      * @see DiskDevice::getTotal()
      *
-     * @return Integer
+     * @return int
      */
     public function getSwapTotal()
     {
@@ -436,7 +436,7 @@ class System
      * @see System::_swapDevices
      * @see DiskDevice::getUsed()
      *
-     * @return Integer
+     * @return int
      */
     public function getSwapUsed()
     {
@@ -458,7 +458,7 @@ class System
      * @see System::getSwapUsed()
      * @see System::getSwapTotal()
      *
-     * @return Integer
+     * @return int
      */
     public function getSwapPercentUsed()
     {
@@ -492,7 +492,7 @@ class System
      *
      * @see System::$_distribution
      *
-     * @return Void
+     * @return void
      */
     public function setDistribution($distribution)
     {
@@ -518,7 +518,7 @@ class System
      *
      * @see System::$_distributionIcon
      *
-     * @return Void
+     * @return void
      */
     public function setDistributionIcon($distributionIcon)
     {
@@ -544,7 +544,7 @@ class System
      *
      * @see System::$_hostname
      *
-     * @return Void
+     * @return void
      */
     public function setHostname($hostname)
     {
@@ -570,7 +570,7 @@ class System
      *
      * @see System::$_ip
      *
-     * @return Void
+     * @return void
      */
     public function setIp($ip)
     {
@@ -596,7 +596,7 @@ class System
      *
      * @see System::$_kernel
      *
-     * @return Void
+     * @return void
      */
     public function setKernel($kernel)
     {
@@ -622,7 +622,7 @@ class System
      *
      * @see System::$_load
      *
-     * @return Void
+     * @return void
      */
     public function setLoad($load)
     {
@@ -634,7 +634,7 @@ class System
      *
      * @see System::$_loadPercent
      *
-     * @return Integer
+     * @return int
      */
     public function getLoadPercent()
     {
@@ -644,11 +644,11 @@ class System
     /**
      * Sets $_loadPercent.
      *
-     * @param Integer $loadPercent load percent
+     * @param int $loadPercent load percent
      *
      * @see System::$_loadPercent
      *
-     * @return Void
+     * @return void
      */
     public function setLoadPercent($loadPercent)
     {
@@ -674,7 +674,7 @@ class System
      *
      * @see System::$_machine
      *
-     * @return Void
+     * @return void
      */
     public function setMachine($machine)
     {
@@ -686,7 +686,7 @@ class System
      *
      * @see System::$_uptime
      *
-     * @return Integer
+     * @return int
      */
     public function getUptime()
     {
@@ -700,7 +700,7 @@ class System
      *
      * @see System::$_uptime
      *
-     * @return Void
+     * @return void
      */
     public function setUptime($uptime)
     {
@@ -712,7 +712,7 @@ class System
      *
      * @see System::$_users
      *
-     * @return Integer
+     * @return int
      */
     public function getUsers()
     {
@@ -722,11 +722,11 @@ class System
     /**
      * Sets $_users.
      *
-     * @param Integer $users user count
+     * @param int $users user count
      *
      * @see System::$_users
      *
-     * @return Void
+     * @return void
      */
     public function setUsers($users)
     {
@@ -753,7 +753,7 @@ class System
      * @see System::$_cpus
      * @see CpuDevice
      *
-     * @return Void
+     * @return void
      */
     public function setCpus($cpus)
     {
@@ -784,7 +784,7 @@ class System
      * @see System::$_netDevices
      * @see NetDevice
      *
-     * @return Void
+     * @return void
      */
     public function setNetDevices($netDevices)
     {
@@ -811,7 +811,7 @@ class System
      * @see System::$_pciDevices
      * @see HWDevice
      *
-     * @return Void
+     * @return void
      */
     public function setPciDevices($pciDevices)
     {
@@ -838,7 +838,7 @@ class System
      * @see System::$_ideDevices
      * @see HWDevice
      *
-     * @return Void
+     * @return void
      */
     public function setIdeDevices($ideDevices)
     {
@@ -865,7 +865,7 @@ class System
      * @see System::$_scsiDevices
      * @see HWDevice
      *
-     * @return Void
+     * @return void
      */
     public function setScsiDevices($scsiDevices)
     {
@@ -892,7 +892,7 @@ class System
      * @see System::$_usbDevices
      * @see HWDevice
      *
-     * @return Void
+     * @return void
      */
     public function setUsbDevices($usbDevices)
     {
@@ -919,7 +919,7 @@ class System
      * @see System::$_tbDevices
      * @see HWDevice
      *
-     * @return Void
+     * @return void
      */
     public function setTbDevices($tbDevices)
     {
@@ -946,7 +946,7 @@ class System
      * @see System::$_i2cDevices
      * @see HWDevice
      *
-     * @return Void
+     * @return void
      */
     public function setI2cDevices($i2cDevices)
     {
@@ -973,7 +973,7 @@ class System
      * @see System::$_nvmeDevices
      * @see HWDevice
      *
-     * @return Void
+     * @return void
      */
     public function setNvmeDevices($nvmeDevices)
     {
@@ -1000,7 +1000,7 @@ class System
      * @see System::$_memDevices
      * @see HWDevice
      *
-     * @return Void
+     * @return void
      */
     public function setMemDevices($memDevices)
     {
@@ -1039,7 +1039,7 @@ class System
      *
      * @see System::$_memApplication
      *
-     * @return Integer
+     * @return int
      */
     public function getMemApplication()
     {
@@ -1049,11 +1049,11 @@ class System
     /**
      * Sets $_memApplication.
      *
-     * @param Integer $memApplication application memory
+     * @param int $memApplication application memory
      *
      * @see System::$_memApplication
      *
-     * @return Void
+     * @return void
      */
     public function setMemApplication($memApplication)
     {
@@ -1065,7 +1065,7 @@ class System
      *
      * @see System::$_memBuffer
      *
-     * @return Integer
+     * @return int
      */
     public function getMemBuffer()
     {
@@ -1075,11 +1075,11 @@ class System
     /**
      * Sets $_memBuffer.
      *
-     * @param Integer $memBuffer buffer memory
+     * @param int $memBuffer buffer memory
      *
      * @see System::$_memBuffer
      *
-     * @return Void
+     * @return void
      */
     public function setMemBuffer($memBuffer)
     {
@@ -1091,7 +1091,7 @@ class System
      *
      * @see System::$_memCache
      *
-     * @return Integer
+     * @return int
      */
     public function getMemCache()
     {
@@ -1101,11 +1101,11 @@ class System
     /**
      * Sets $_memCache.
      *
-     * @param Integer $memCache cache memory
+     * @param int $memCache cache memory
      *
      * @see System::$_memCache
      *
-     * @return Void
+     * @return void
      */
     public function setMemCache($memCache)
     {
@@ -1117,7 +1117,7 @@ class System
      *
      * @see System::$_memFree
      *
-     * @return Integer
+     * @return int
      */
     public function getMemFree()
     {
@@ -1127,11 +1127,11 @@ class System
     /**
      * Sets $_memFree.
      *
-     * @param Integer $memFree free memory
+     * @param int $memFree free memory
      *
      * @see System::$_memFree
      *
-     * @return Void
+     * @return void
      */
     public function setMemFree($memFree)
     {
@@ -1143,7 +1143,7 @@ class System
      *
      * @see System::$_memTotal
      *
-     * @return Integer
+     * @return int
      */
     public function getMemTotal()
     {
@@ -1153,11 +1153,11 @@ class System
     /**
      * Sets $_memTotal.
      *
-     * @param Integer $memTotal total memory
+     * @param int $memTotal total memory
      *
      * @see System::$_memTotal
      *
-     * @return Void
+     * @return void
      */
     public function setMemTotal($memTotal)
     {
@@ -1169,7 +1169,7 @@ class System
      *
      * @see System::$_memUsed
      *
-     * @return Integer
+     * @return int
      */
     public function getMemUsed()
     {
@@ -1179,11 +1179,11 @@ class System
     /**
      * Sets $_memUsed.
      *
-     * @param Integer $memUsed used memory
+     * @param int $memUsed used memory
      *
      * @see System::$_memUsed
      *
-     * @return Void
+     * @return void
      */
     public function setMemUsed($memUsed)
     {
@@ -1210,7 +1210,7 @@ class System
      * @see System::$_swapDevices
      * @see DiskDevice
      *
-     * @return Void
+     * @return void
      */
     public function setSwapDevices($swapDevices)
     {
@@ -1236,7 +1236,7 @@ class System
      *
      * @see System::$_processes
      *
-     * @return Void
+     * @return void
      */
     public function setProcesses($processes)
     {
@@ -1268,7 +1268,7 @@ class System
      *
      * @see System::$_virtualizer
      *
-     * @return Void
+     * @return void
      */
     public function setVirtualizer($virtualizer, $value = true)
     {

--- a/includes/to/device/class.CpuDevice.inc.php
+++ b/includes/to/device/class.CpuDevice.inc.php
@@ -28,77 +28,77 @@ class CpuDevice
     /**
      * model of the cpu
      *
-     * @var String
+     * @var string
      */
     private $_model = "";
 
     /**
      * speed of the cpu in hertz
      *
-     * @var Integer
+     * @var int
      */
     private $_cpuSpeed = 0;
 
     /**
      * max speed of the cpu in hertz
      *
-     * @var Integer
+     * @var int
      */
     private $_cpuSpeedMax = 0;
 
     /**
      * min speed of the cpu in hertz
      *
-     * @var Integer
+     * @var int
      */
     private $_cpuSpeedMin = 0;
 
     /**
      * cache size in bytes, if available
      *
-     * @var Integer
+     * @var int
      */
     private $_cache = null;
 
     /**
      * virtualization, if available
      *
-     * @var String
+     * @var string
      */
     private $_virt = null;
 
     /**
      * busspeed in hertz, if available
      *
-     * @var Integer
+     * @var int
      */
     private $_busSpeed = null;
 
     /**
      * bogomips of the cpu, if available
      *
-     * @var Integer
+     * @var int
      */
     private $_bogomips = null;
 
     /**
      * temperature of the cpu, if available
      *
-     * @var Integer
+     * @var int
      */
     private $_temp = null;
 
     /**
      * vendorid, if available
      *
-     * @var String
+     * @var string
      */
     private $_vendorid = null;
 
     /**
      * current load in percent of the cpu, if available
      *
-     * @var Integer
+     * @var int
      */
     private $_load = null;
 
@@ -121,7 +121,7 @@ class CpuDevice
      *
      * @see Cpu::$_model
      *
-     * @return Void
+     * @return void
      */
     public function setModel($model)
     {
@@ -133,7 +133,7 @@ class CpuDevice
      *
      * @see Cpu::$_cpuSpeed
      *
-     * @return Integer
+     * @return int
      */
     public function getCpuSpeed()
     {
@@ -143,11 +143,11 @@ class CpuDevice
     /**
      * Sets $_cpuSpeed.
      *
-     * @param Integer $cpuSpeed cpuspeed
+     * @param int $cpuSpeed cpuspeed
      *
      * @see Cpu::$_cpuSpeed
      *
-     * @return Void
+     * @return void
      */
     public function setCpuSpeed($cpuSpeed)
     {
@@ -159,7 +159,7 @@ class CpuDevice
      *
      * @see Cpu::$_cpuSpeedMAx
      *
-     * @return Integer
+     * @return int
      */
     public function getCpuSpeedMax()
     {
@@ -169,11 +169,11 @@ class CpuDevice
     /**
      * Sets $_cpuSpeedMax.
      *
-     * @param Integer $cpuSpeedMax cpuspeedmax
+     * @param int $cpuSpeedMax cpuspeedmax
      *
      * @see Cpu::$_cpuSpeedMax
      *
-     * @return Void
+     * @return void
      */
     public function setCpuSpeedMax($cpuSpeedMax)
     {
@@ -185,7 +185,7 @@ class CpuDevice
      *
      * @see Cpu::$_cpuSpeedMin
      *
-     * @return Integer
+     * @return int
      */
     public function getCpuSpeedMin()
     {
@@ -195,11 +195,11 @@ class CpuDevice
     /**
      * Sets $_cpuSpeedMin.
      *
-     * @param Integer $cpuSpeedMin cpuspeedmin
+     * @param int $cpuSpeedMin cpuspeedmin
      *
      * @see Cpu::$_cpuSpeedMin
      *
-     * @return Void
+     * @return void
      */
     public function setCpuSpeedMin($cpuSpeedMin)
     {
@@ -211,7 +211,7 @@ class CpuDevice
      *
      * @see Cpu::$_cache
      *
-     * @return Integer
+     * @return int
      */
     public function getCache()
     {
@@ -221,11 +221,11 @@ class CpuDevice
     /**
      * Sets $_cache.
      *
-     * @param Integer $cache cache size
+     * @param int $cache cache size
      *
      * @see Cpu::$_cache
      *
-     * @return Void
+     * @return void
      */
     public function setCache($cache)
     {
@@ -251,7 +251,7 @@ class CpuDevice
      *
      * @see Cpu::$_virt
      *
-     * @return Void
+     * @return void
      */
     public function setVirt($virt)
     {
@@ -263,7 +263,7 @@ class CpuDevice
      *
      * @see Cpu::$_busSpeed
      *
-     * @return Integer
+     * @return int
      */
     public function getBusSpeed()
     {
@@ -273,11 +273,11 @@ class CpuDevice
     /**
      * Sets $_busSpeed.
      *
-     * @param Integer $busSpeed busspeed
+     * @param int $busSpeed busspeed
      *
      * @see Cpu::$_busSpeed
      *
-     * @return Void
+     * @return void
      */
     public function setBusSpeed($busSpeed)
     {
@@ -289,7 +289,7 @@ class CpuDevice
      *
      * @see Cpu::$_bogomips
      *
-     * @return Integer
+     * @return int
      */
     public function getBogomips()
     {
@@ -299,11 +299,11 @@ class CpuDevice
     /**
      * Sets $_bogomips.
      *
-     * @param Integer $bogomips bogompis
+     * @param int $bogomips bogompis
      *
      * @see Cpu::$_bogomips
      *
-     * @return Void
+     * @return void
      */
     public function setBogomips($bogomips)
     {
@@ -315,7 +315,7 @@ class CpuDevice
      *
      * @see Cpu::$_temp
      *
-     * @return Integer
+     * @return int
      */
 /*
     public function getTemp()
@@ -327,11 +327,11 @@ class CpuDevice
     /**
      * Sets $_temp.
      *
-     * @param Integer $temp temperature
+     * @param int $temp temperature
      *
      * @see Cpu::$_temp
      *
-     * @return Void
+     * @return void
      */
 /*
     public function setTemp($temp)
@@ -359,7 +359,7 @@ class CpuDevice
      *
      * @see Cpu::$_vendorid
      *
-     * @return Void
+     * @return void
      */
     public function setVendorId($vendorid)
     {
@@ -371,7 +371,7 @@ class CpuDevice
      *
      * @see CpuDevice::$_load
      *
-     * @return Integer
+     * @return int
      */
     public function getLoad()
     {
@@ -381,11 +381,11 @@ class CpuDevice
     /**
      * Sets $_load.
      *
-     * @param Integer $load load percent
+     * @param int $load load percent
      *
      * @see CpuDevice::$_load
      *
-     * @return Void
+     * @return void
      */
     public function setLoad($load)
     {

--- a/includes/to/device/class.DiskDevice.inc.php
+++ b/includes/to/device/class.DiskDevice.inc.php
@@ -28,63 +28,63 @@ class DiskDevice
     /**
      * name of the disk device
      *
-     * @var String
+     * @var string
      */
     private $_name = "";
 
     /**
      * type of the filesystem on the disk device
      *
-     * @var String
+     * @var string
      */
     private $_fsType = "";
 
     /**
      * diskspace that is free in bytes
      *
-     * @var Integer
+     * @var int
      */
     private $_free = 0;
 
     /**
      * diskspace that is used in bytes
      *
-     * @var Integer
+     * @var int
      */
     private $_used = 0;
 
     /**
      * total diskspace
      *
-     * @var Integer
+     * @var int
      */
     private $_total = 0;
 
     /**
      * mount point of the disk device if available
      *
-     * @var String
+     * @var string
      */
     private $_mountPoint = null;
 
     /**
      * additional options of the device, like mount options
      *
-     * @var String
+     * @var string
      */
     private $_options = null;
 
     /**
      * inodes usage in percent if available
      *
-     * @var Integer
+     * @var int
      */
     private $_percentInodesUsed = null;
 
     /**
      * ignore mode
      *
-     * @var Integer
+     * @var int
      */
     private $_ignore = 0;
 
@@ -94,7 +94,7 @@ class DiskDevice
      * @see DiskDevice::$_total
      * @see DiskDevice::$_used
      *
-     * @return Integer
+     * @return int
      */
     public function getPercentUsed()
     {
@@ -110,7 +110,7 @@ class DiskDevice
      *
      * @see DiskDevice::$_PercentInodesUsed
      *
-     * @return Integer
+     * @return int
      */
     public function getPercentInodesUsed()
     {
@@ -120,11 +120,11 @@ class DiskDevice
     /**
      * Sets $_PercentInodesUsed.
      *
-     * @param Integer $percentInodesUsed inodes percent
+     * @param int $percentInodesUsed inodes percent
      *
      * @see DiskDevice::$_PercentInodesUsed
      *
-     * @return Void
+     * @return void
      */
     public function setPercentInodesUsed($percentInodesUsed)
     {
@@ -136,7 +136,7 @@ class DiskDevice
      *
      * @see DiskDevice::$_free
      *
-     * @return Integer
+     * @return int
      */
     public function getFree()
     {
@@ -146,11 +146,11 @@ class DiskDevice
     /**
      * Sets $_free.
      *
-     * @param Integer $free free bytes
+     * @param int $free free bytes
      *
      * @see DiskDevice::$_free
      *
-     * @return Void
+     * @return void
      */
     public function setFree($free)
     {
@@ -162,7 +162,7 @@ class DiskDevice
      *
      * @see DiskDevice::$_fsType
      *
-     * @return String
+     * @return string
      */
     public function getFsType()
     {
@@ -176,7 +176,7 @@ class DiskDevice
      *
      * @see DiskDevice::$_fsType
      *
-     * @return Void
+     * @return void
      */
     public function setFsType($fsType)
     {
@@ -188,7 +188,7 @@ class DiskDevice
      *
      * @see DiskDevice::$_mountPoint
      *
-     * @return String
+     * @return string
      */
     public function getMountPoint()
     {
@@ -198,11 +198,11 @@ class DiskDevice
     /**
      * Sets $_mountPoint.
      *
-     * @param String $mountPoint mountpoint
+     * @param string $mountPoint mountpoint
      *
      * @see DiskDevice::$_mountPoint
      *
-     * @return Void
+     * @return void
      */
     public function setMountPoint($mountPoint)
     {
@@ -214,7 +214,7 @@ class DiskDevice
      *
      * @see DiskDevice::$_name
      *
-     * @return String
+     * @return string
      */
     public function getName()
     {
@@ -224,11 +224,11 @@ class DiskDevice
     /**
      * Sets $_name.
      *
-     * @param String $name device name
+     * @param string $name device name
      *
      * @see DiskDevice::$_name
      *
-     * @return Void
+     * @return void
      */
     public function setName($name)
     {
@@ -240,7 +240,7 @@ class DiskDevice
      *
      * @see DiskDevice::$_options
      *
-     * @return String
+     * @return string
      */
     public function getOptions()
     {
@@ -250,11 +250,11 @@ class DiskDevice
     /**
      * Sets $_options.
      *
-     * @param String $options additional options
+     * @param string $options additional options
      *
      * @see DiskDevice::$_options
      *
-     * @return Void
+     * @return void
      */
     public function setOptions($options)
     {
@@ -266,7 +266,7 @@ class DiskDevice
      *
      * @see DiskDevice::$_total
      *
-     * @return Integer
+     * @return int
      */
     public function getTotal()
     {
@@ -276,11 +276,11 @@ class DiskDevice
     /**
      * Sets $_total.
      *
-     * @param Integer $total total bytes
+     * @param int $total total bytes
      *
      * @see DiskDevice::$_total
      *
-     * @return Void
+     * @return void
      */
     public function setTotal($total)
     {
@@ -292,7 +292,7 @@ class DiskDevice
      *
      * @see DiskDevice::$_used
      *
-     * @return Integer
+     * @return int
      */
     public function getUsed()
     {
@@ -302,11 +302,11 @@ class DiskDevice
     /**
      * Sets $_used.
      *
-     * @param Integer $used used bytes
+     * @param int $used used bytes
      *
      * @see DiskDevice::$_used
      *
-     * @return Void
+     * @return void
      */
     public function setUsed($used)
     {
@@ -318,7 +318,7 @@ class DiskDevice
      *
      * @see DiskDevice::$_ignore
      *
-     * @return Integer
+     * @return int
      */
     public function getIgnore()
     {
@@ -330,7 +330,7 @@ class DiskDevice
      *
      * @see DiskDevice::$_ignore
      *
-     * @return Void
+     * @return void
      */
     public function setIgnore($ignore)
     {

--- a/includes/to/device/class.HWDevice.inc.php
+++ b/includes/to/device/class.HWDevice.inc.php
@@ -28,35 +28,35 @@ class HWDevice
     /**
      * name of the device
      *
-     * @var String
+     * @var string
      */
     private $_name = "";
 
     /**
      * capacity of the device, if not available it will be null
      *
-     * @var Integer
+     * @var int
      */
     private $_capacity = null;
 
     /**
      * manufacturer of the device, if not available it will be null
      *
-     * @var Integer
+     * @var int
      */
     private $_manufacturer = null;
 
     /**
      * product of the device, if not available it will be null
      *
-     * @var Integer
+     * @var int
      */
     private $_product = null;
 
     /**
      * serial number of the device, if not available it will be null
      *
-     * @var String
+     * @var string
      */
     private $_serial = null;
 
@@ -77,7 +77,7 @@ class HWDevice
     /**
      * count of the device
      *
-     * @var Integer
+     * @var int
      */
     private $_count = 1;
 
@@ -121,7 +121,7 @@ class HWDevice
      *
      * @see HWDevice::$_name
      *
-     * @return Void
+     * @return void
      */
     public function setName($name)
     {
@@ -147,7 +147,7 @@ class HWDevice
      *
      * @see HWDevice::$_manufacturer
      *
-     * @return Void
+     * @return void
      */
     public function setManufacturer($manufacturer)
     {
@@ -173,7 +173,7 @@ class HWDevice
      *
      * @see HWDevice::$_product
      *
-     * @return Void
+     * @return void
      */
     public function setProduct($product)
     {
@@ -199,7 +199,7 @@ class HWDevice
      *
      * @see HWDevice::$_serial
      *
-     * @return Void
+     * @return void
      */
     public function setSerial($serial)
     {
@@ -225,7 +225,7 @@ class HWDevice
      *
      * @see HWDevice::$_speed
      *
-     * @return Void
+     * @return void
      */
     public function setSpeed($speed)
     {
@@ -251,7 +251,7 @@ class HWDevice
      *
      * @see HWDevice::$_voltage
      *
-     * @return Void
+     * @return void
      */
     public function setVoltage($voltage)
     {
@@ -263,7 +263,7 @@ class HWDevice
      *
      * @see HWDevice::$_capacity
      *
-     * @return Integer
+     * @return int
      */
     public function getCapacity()
     {
@@ -273,11 +273,11 @@ class HWDevice
     /**
      * Sets $_capacity.
      *
-     * @param Integer $capacity device capacity
+     * @param int $capacity device capacity
      *
      * @see HWDevice::$_capacity
      *
-     * @return Void
+     * @return void
      */
     public function setCapacity($capacity)
     {
@@ -289,7 +289,7 @@ class HWDevice
      *
      * @see HWDevice::$_count
      *
-     * @return Integer
+     * @return int
      */
     public function getCount()
     {
@@ -299,11 +299,11 @@ class HWDevice
     /**
      * Sets $_count.
      *
-     * @param Integer $count device count
+     * @param int $count device count
      *
      * @see HWDevice::$_count
      *
-     * @return Void
+     * @return void
      */
     public function setCount($count)
     {

--- a/includes/to/device/class.NetDevice.inc.php
+++ b/includes/to/device/class.NetDevice.inc.php
@@ -28,42 +28,42 @@ class NetDevice
     /**
      * name of the device
      *
-     * @var String
+     * @var string
      */
     private $_name = "";
 
     /**
      * transmitted bytes
      *
-     * @var Integer
+     * @var int
      */
     private $_txBytes = 0;
 
     /**
      * received bytes
      *
-     * @var Integer
+     * @var int
      */
     private $_rxBytes = 0;
 
     /**
      * counted error packages
      *
-     * @var Integer
+     * @var int
      */
     private $_errors = 0;
 
     /**
      * counted droped packages
      *
-     * @var Integer
+     * @var int
      */
     private $_drops = 0;
 
     /**
      * string with info
      *
-     * @var String
+     * @var string
      */
     private $_info = null;
 
@@ -72,7 +72,7 @@ class NetDevice
      *
      * @see NetDevice::$_drops
      *
-     * @return Integer
+     * @return int
      */
     public function getDrops()
     {
@@ -82,11 +82,11 @@ class NetDevice
     /**
      * Sets $_drops.
      *
-     * @param Integer $drops dropped packages
+     * @param int $drops dropped packages
      *
      * @see NetDevice::$_drops
      *
-     * @return Void
+     * @return void
      */
     public function setDrops($drops)
     {
@@ -98,7 +98,7 @@ class NetDevice
      *
      * @see NetDevice::$_errors
      *
-     * @return Integer
+     * @return int
      */
     public function getErrors()
     {
@@ -108,11 +108,11 @@ class NetDevice
     /**
      * Sets $_errors.
      *
-     * @param Integer $errors error packages
+     * @param int $errors error packages
      *
      * @see NetDevice::$_errors
      *
-     * @return Void
+     * @return void
      */
     public function setErrors($errors)
     {
@@ -138,7 +138,7 @@ class NetDevice
      *
      * @see NetDevice::$_name
      *
-     * @return Void
+     * @return void
      */
     public function setName($name)
     {
@@ -150,7 +150,7 @@ class NetDevice
      *
      * @see NetDevice::$_rxBytes
      *
-     * @return Integer
+     * @return int
      */
     public function getRxBytes()
     {
@@ -160,11 +160,11 @@ class NetDevice
     /**
      * Sets $_rxBytes.
      *
-     * @param Integer $rxBytes received bytes
+     * @param int $rxBytes received bytes
      *
      * @see NetDevice::$_rxBytes
      *
-     * @return Void
+     * @return void
      */
     public function setRxBytes($rxBytes)
     {
@@ -176,7 +176,7 @@ class NetDevice
      *
      * @see NetDevice::$_txBytes
      *
-     * @return Integer
+     * @return int
      */
     public function getTxBytes()
     {
@@ -186,11 +186,11 @@ class NetDevice
     /**
      * Sets $_txBytes.
      *
-     * @param Integer $txBytes transmitted bytes
+     * @param int $txBytes transmitted bytes
      *
      * @see NetDevice::$_txBytes
      *
-     * @return Void
+     * @return void
      */
     public function setTxBytes($txBytes)
     {
@@ -216,7 +216,7 @@ class NetDevice
      *
      * @see NetDevice::$_info
      *
-     * @return Void
+     * @return void
      */
     public function setInfo($info)
     {

--- a/includes/to/device/class.SensorDevice.inc.php
+++ b/includes/to/device/class.SensorDevice.inc.php
@@ -28,42 +28,42 @@ class SensorDevice
     /**
      * name of the sensor
      *
-     * @var String
+     * @var string
      */
     private $_name = "";
 
     /**
      * current value of the sensor
      *
-     * @var Integer
+     * @var int
      */
     private $_value = 0;
 
     /**
      * maximum value of the sensor
      *
-     * @var Integer
+     * @var int
      */
     private $_max = null;
 
     /**
      * minimum value of the sensor
      *
-     * @var Integer
+     * @var int
      */
     private $_min = null;
 
     /**
      * event of the sensor
      *
-     * @var String
+     * @var string
      */
     private $_event = "";
 
     /**
      * unit of values of the sensor
      *
-     * @var String
+     * @var string
      */
     private $_unit = "";
 
@@ -72,7 +72,7 @@ class SensorDevice
      *
      * @see Sensor::$_max
      *
-     * @return Integer
+     * @return int
      */
     public function getMax()
     {
@@ -82,11 +82,11 @@ class SensorDevice
     /**
      * Sets $_max.
      *
-     * @param Integer $max maximum value
+     * @param int $max maximum value
      *
      * @see Sensor::$_max
      *
-     * @return Void
+     * @return void
      */
     public function setMax($max)
     {
@@ -98,7 +98,7 @@ class SensorDevice
      *
      * @see Sensor::$_min
      *
-     * @return Integer
+     * @return int
      */
     public function getMin()
     {
@@ -108,11 +108,11 @@ class SensorDevice
     /**
      * Sets $_min.
      *
-     * @param Integer $min minimum value
+     * @param int $min minimum value
      *
      * @see Sensor::$_min
      *
-     * @return Void
+     * @return void
      */
     public function setMin($min)
     {
@@ -138,7 +138,7 @@ class SensorDevice
      *
      * @see Sensor::$_name
      *
-     * @return Void
+     * @return void
      */
     public function setName($name)
     {
@@ -150,7 +150,7 @@ class SensorDevice
      *
      * @see Sensor::$_value
      *
-     * @return Integer
+     * @return int
      */
     public function getValue()
     {
@@ -160,11 +160,11 @@ class SensorDevice
     /**
      * Sets $_value.
      *
-     * @param Integer $value current value
+     * @param int $value current value
      *
      * @see Sensor::$_value
      *
-     * @return Void
+     * @return void
      */
     public function setValue($value)
     {
@@ -190,7 +190,7 @@ class SensorDevice
      *
      * @see Sensor::$_event
      *
-     * @return Void
+     * @return void
      */
     public function setEvent($event)
     {
@@ -216,7 +216,7 @@ class SensorDevice
      *
      * @see Sensor::$_unit
      *
-     * @return Void
+     * @return void
      */
     public function setUnit($unit)
     {

--- a/includes/to/device/class.UPSDevice.inc.php
+++ b/includes/to/device/class.UPSDevice.inc.php
@@ -28,119 +28,119 @@ class UPSDevice
     /**
      * name of the ups
      *
-     * @var String
+     * @var string
      */
     private $_name = "";
 
     /**
      * model of the ups
      *
-     * @var String
+     * @var string
      */
     private $_model = "";
 
     /**
      * mode of the ups
      *
-     * @var String
+     * @var string
      */
     private $_mode = "";
 
     /**
      * last start time
      *
-     * @var String
+     * @var string
      */
     private $_startTime = "";
 
     /**
      * status of the ups
      *
-     * @var String
+     * @var string
      */
     private $_status = "";
 
     /**
      * temperature of the ups
      *
-     * @var Integer
+     * @var int
      */
     private $_temperatur = null;
 
     /**
      * outages count
      *
-     * @var Integer
+     * @var int
      */
     private $_outages = null;
 
     /**
      * date of last outtage
      *
-     * @var String
+     * @var string
      */
     private $_lastOutage = null;
 
     /**
      * date of last outage finish
      *
-     * @var String
+     * @var string
      */
     private $_lastOutageFinish = null;
 
     /**
      * line volt
      *
-     * @var Integer
+     * @var int
      */
     private $_lineVoltage = null;
 
     /**
      * line freq
      *
-     * @var Integer
+     * @var int
      */
     private $_lineFrequency = null;
 
     /**
      * current load of the ups in percent
      *
-     * @var Integer
+     * @var int
      */
     private $_load = null;
 
     /**
      * battery installation date
      *
-     * @var String
+     * @var string
      */
     private $_batteryDate = null;
 
     /**
      * current battery volt
      *
-     * @var Integer
+     * @var int
      */
     private $_batteryVoltage = null;
 
     /**
      * current charge in percent of the battery
      *
-     * @var Integer
+     * @var int
      */
     private $_batterCharge = null;
 
     /**
      * time left
      *
-     * @var String
+     * @var string
      */
     private $_timeLeft = null;
 
     /**
      * beeper enabled or disabled
      *
-     * @var String
+     * @var string
      */
     private $_beeperStatus = null;
 
@@ -159,7 +159,7 @@ class UPSDevice
     /**
      * Sets $_batterCharge.
      *
-     * @param Integer $batterCharge battery charge
+     * @param int $batterCharge battery charge
      *
      * @see UPSDevice::$_batterCharge
      *
@@ -189,7 +189,7 @@ class UPSDevice
      *
      * @see UPSDevice::$_batteryDate
      *
-     * @return Void
+     * @return void
      */
     public function setBatteryDate($batteryDate)
     {
@@ -201,7 +201,7 @@ class UPSDevice
      *
      * @see UPSDevice::$_batteryVoltage
      *
-     * @return Integer
+     * @return int
      */
     public function getBatteryVoltage()
     {
@@ -211,11 +211,11 @@ class UPSDevice
     /**
      * Sets $_batteryVoltage.
      *
-     * @param Integer $batteryVoltage battery volt
+     * @param int $batteryVoltage battery volt
      *
      * @see UPSDevice::$_batteryVoltage
      *
-     * @return Void
+     * @return void
      */
     public function setBatteryVoltage($batteryVoltage)
     {
@@ -241,7 +241,7 @@ class UPSDevice
      *
      * @see UPSDevice::$lastOutage
      *
-     * @return Void
+     * @return void
      */
     public function setLastOutage($lastOutage)
     {
@@ -267,7 +267,7 @@ class UPSDevice
      *
      * @see UPSDevice::$_lastOutageFinish
      *
-     * @return Void
+     * @return void
      */
     public function setLastOutageFinish($lastOutageFinish)
     {
@@ -279,7 +279,7 @@ class UPSDevice
      *
      * @see UPSDevice::$_lineVoltage
      *
-     * @return Integer
+     * @return int
      */
     public function getLineVoltage()
     {
@@ -289,11 +289,11 @@ class UPSDevice
     /**
      * Sets $_lineVoltage.
      *
-     * @param Integer $lineVoltage line voltage
+     * @param int $lineVoltage line voltage
      *
      * @see UPSDevice::$_lineVoltage
      *
-     * @return Void
+     * @return void
      */
     public function setLineVoltage($lineVoltage)
     {
@@ -305,7 +305,7 @@ class UPSDevice
      *
      * @see UPSDevice::$_lineFrequency
      *
-     * @return Integer
+     * @return int
      */
     public function getLineFrequency()
     {
@@ -315,11 +315,11 @@ class UPSDevice
     /**
      * Sets $_lineFrequency.
      *
-     * @param Integer $lineFrequency line frequency
+     * @param int $lineFrequency line frequency
      *
      * @see UPSDevice::$_lineFrequency
      *
-     * @return Void
+     * @return void
      */
     public function setLineFrequency($lineFrequency)
     {
@@ -331,7 +331,7 @@ class UPSDevice
      *
      * @see UPSDevice::$_load
      *
-     * @return Integer
+     * @return int
      */
     public function getLoad()
     {
@@ -341,11 +341,11 @@ class UPSDevice
     /**
      * Sets $_load.
      *
-     * @param Integer $load current load
+     * @param int $load current load
      *
      * @see UPSDevice::$_load
      *
-     * @return Void
+     * @return void
      */
     public function setLoad($load)
     {
@@ -371,7 +371,7 @@ class UPSDevice
      *
      * @see UPSDevice::$_mode
      *
-     * @return Void
+     * @return void
      */
     public function setMode($mode)
     {
@@ -397,7 +397,7 @@ class UPSDevice
      *
      * @see UPSDevice::$_model
      *
-     * @return Void
+     * @return void
      */
     public function setModel($model)
     {
@@ -423,7 +423,7 @@ class UPSDevice
      *
      * @see UPSDevice::$_name
      *
-     * @return Void
+     * @return void
      */
     public function setName($name)
     {
@@ -435,7 +435,7 @@ class UPSDevice
      *
      * @see UPSDevice::$_outages
      *
-     * @return Integer
+     * @return int
      */
     public function getOutages()
     {
@@ -445,11 +445,11 @@ class UPSDevice
     /**
      * Sets $_outages.
      *
-     * @param Integer $outages outages count
+     * @param int $outages outages count
      *
      * @see UPSDevice::$_outages
      *
-     * @return Void
+     * @return void
      */
     public function setOutages($outages)
     {
@@ -475,7 +475,7 @@ class UPSDevice
      *
      * @see UPSDevice::$_startTime
      *
-     * @return Void
+     * @return void
      */
     public function setStartTime($startTime)
     {
@@ -501,7 +501,7 @@ class UPSDevice
      *
      * @see UPSDevice::$_status
      *
-     * @return Void
+     * @return void
      */
     public function setStatus($status)
     {
@@ -513,7 +513,7 @@ class UPSDevice
      *
      * @see UPSDevice::$_temperatur
      *
-     * @return Integer
+     * @return int
      */
     public function getTemperatur()
     {
@@ -523,11 +523,11 @@ class UPSDevice
     /**
      * Sets $_temperatur.
      *
-     * @param Integer $temperatur temperature
+     * @param int $temperatur temperature
      *
      * @see UPSDevice::$_temperatur
      *
-     * @return Void
+     * @return void
      */
     public function setTemperatur($temperatur)
     {
@@ -553,7 +553,7 @@ class UPSDevice
      *
      * @see UPSDevice::$_timeLeft
      *
-     * @return Void
+     * @return void
      */
     public function setTimeLeft($timeLeft)
     {
@@ -579,7 +579,7 @@ class UPSDevice
      *
      * @see UPSDevice::$_beeperStatus
      *
-     * @return Void
+     * @return void
      */
     public function setBeeperStatus($beeperStatus)
     {

--- a/includes/ups/class.apcupsd.inc.php
+++ b/includes/ups/class.apcupsd.inc.php
@@ -93,7 +93,7 @@ class Apcupsd extends UPS
     /**
      * parse the input and store data in resultset for xml generation
      *
-     * @return Void
+     * @return void
      */
     private function _info()
     {
@@ -170,7 +170,7 @@ class Apcupsd extends UPS
      *
      * @see PSI_Interface_UPS::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/ups/class.nut.inc.php
+++ b/includes/ups/class.nut.inc.php
@@ -169,7 +169,7 @@ class Nut extends UPS
      *
      * @see PSI_Interface_UPS::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/ups/class.pmset.inc.php
+++ b/includes/ups/class.pmset.inc.php
@@ -92,7 +92,7 @@ class Pmset extends UPS
      *
      * @see PSI_Interface_UPS::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/ups/class.powersoftplus.inc.php
+++ b/includes/ups/class.powersoftplus.inc.php
@@ -54,7 +54,7 @@ class PowerSoftPlus extends UPS
     /**
      * parse the input and store data in resultset for xml generation
      *
-     * @return Void
+     * @return void
      */
     private function _info()
     {
@@ -113,7 +113,7 @@ class PowerSoftPlus extends UPS
      *
      * @see PSI_Interface_UPS::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/ups/class.snmpups.inc.php
+++ b/includes/ups/class.snmpups.inc.php
@@ -167,7 +167,7 @@ class SNMPups extends UPS
     /**
      * parse the input and store data in resultset for xml generation
      *
-     * @return Void
+     * @return void
      */
     private function _info()
     {
@@ -302,7 +302,7 @@ class SNMPups extends UPS
      *
      * @see PSI_Interface_UPS::build()
      *
-     * @return Void
+     * @return void
      */
     public function build()
     {

--- a/includes/xml/class.SimpleXMLExtended.inc.php
+++ b/includes/xml/class.SimpleXMLExtended.inc.php
@@ -28,7 +28,7 @@ class SimpleXMLExtended
     /**
      * store the encoding that is used for conversation to utf8
      *
-     * @var String base encoding
+     * @var string base encoding
      */
     private $_encoding = null;
 
@@ -139,7 +139,7 @@ class SimpleXMLExtended
      * @param String $name  name of the attribute
      * @param String $value value of the attribute
      *
-     * @return Void
+     * @return void
      */
     public function addAttribute($name, $value)
     {
@@ -157,7 +157,7 @@ class SimpleXMLExtended
      *
      * @param SimpleXMLElement $new_child child that should be appended
      *
-     * @return Void
+     * @return void
      */
     public function combinexml(SimpleXMLElement $new_child)
     {

--- a/includes/xml/class.XML.inc.php
+++ b/includes/xml/class.XML.inc.php
@@ -470,9 +470,9 @@ class XML
      *
      * @param SimpleXmlExtended $mount Xml-Element
      * @param DiskDevice        $dev   DiskDevice
-     * @param Integer           $i     counter
+     * @param int           $i     counter
      *
-     * @return Void
+     * @return void
      */
     private function _fillDevice(SimpleXMLExtended $mount, DiskDevice $dev, $i)
     {


### PR DESCRIPTION
This replaces some invalid things in the phpdoc blocks that e.g. vimeo/psalm will moan about : 

| From | To | --|
|------|-----|----|
| @param Integer | @param int |  no object 'Integer' exists
| @param integer | @param int | invalid type ... needs to be 'int'
| @param String | @param string | no object 'String' exists 
| @return Void | @return void | no object 'Void' exists
| @return Integer | @return int | no object Integer exists

etc

### Summary ###

Update code documentation (phpdoc) to follow more modern standards.

### Types of changes ###

- [ ] Bug fix (non-breaking change which fixes an issue)

### Code Preparation ###

- [x] Check for unused code
- [x] No unrelated changes are included
- [x None of the changed files are reformatting only
- [x] Code is self explanatory or documented
- [x] All written text is properly translated (english language)
