### PR TITLE
openSUSE Tumbleweed to detected distros

### DIFF
--- a/data/distros.ini
+++ b/data/distros.ini
@@ -979,6 +979,10 @@ Image = "openSUSE.png"
 Image = "openSUSE.png"
 ;detected in "/etc/os-release"
 
+[openSUSE Tumbleweed]
+Image = "openSUSE.png"
+;detected in "/etc/os-release"
+
 [openSUSE project]
 Image = "openSUSE.png"
 ;detected in "lsb_release -a"


### PR DESCRIPTION
The 'openSUSE Tumbleweed' distribution used to be detected out-of-the-box, but apparently something changed. Fixed.