### PR TITLE
Fix: constant E_STRICT is deprecated since PHP 8.4

### DIFF
--- a/includes/autoloader.inc.php
+++ b/includes/autoloader.inc.php
@@ -13,7 +13,7 @@
  * @link      http://phpsysinfo.sourceforge.net
  */
 
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 /**
  * automatic loading classes when using them


### PR DESCRIPTION
### Summary ###
Issue: on PHP 8.4 the following warning broke rendering of whole phpsysinfo interface

`Constant E_STRICT is deprecated in phpsysinfo/includes/autoloader.inc.php`

Constant E_STRICT was deprecated in this php-src commit: https://github.com/php/php-src/pull/13053

### Types of changes ###
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)