### PR TITLE
Fix fatal errors on macOS with PHP 8

### DIFF
--- a/includes/os/class.Darwin.inc.php
+++ b/includes/os/class.Darwin.inc.php
@@ -46,9 +46,9 @@ class Darwin extends BSDCommon
 	 *
 	 * @return string
 	 */
-	protected function grabkey($key)
+	protected function grabkey($key, $debug = PSI_DEBUG)
 	{
-		if (CommonFunctions::executeProgram('sysctl', $key, $s, PSI_DEBUG)) {
+		if (CommonFunctions::executeProgram('sysctl', $key, $s, $debug)) {
 			$s = preg_replace('/'.$key.': /', '', $s);
 			$s = preg_replace('/'.$key.' = /', '', $s);
 
@@ -128,8 +128,15 @@ class Darwin extends BSDCommon
 				}
 			}
 		}
-		$dev->setCpuSpeed(round($this->grabkey('hw.cpufrequency') / 1000000));
-		$dev->setBusSpeed(round($this->grabkey('hw.busfrequency') / 1000000));
+		$buf = $this->grabkey('hw.cpufrequency');
+		if ($buf !== null && is_numeric($buf = trim($buf))) {
+			$dev->setCpuSpeed(round($buf / 1000000));
+		}
+
+		$buf = $this->grabkey('hw.busfrequency');
+		if ($buf !== null && is_numeric($buf = trim($buf))) {
+			$dev->setBusSpeed(round($buf / 1000000));
+		}
 		$bufn=$this->grabkey('hw.cpufrequency_min');
 		$bufx=$this->grabkey('hw.cpufrequency_max');
 		if (($bufn !== null) && (trim($bufn) != "") && ($bufx !== null) && (trim($bufx) != "") && ($bufn != $bufx)) {


### PR DESCRIPTION
Fixes #426

### Summary ###
On PHP 8, phpSysInfo is completely broken on macOS: `Darwin::grabkey($key)` is incompatible with the parent declaration `BSDCommon::grabkey($key, $debug = PSI_DEBUG)` (the `$debug` parameter was added to the parent in d12367b9 without updating the Darwin override), which is a fatal error since PHP 8.

This PR matches the override to the parent signature and passes `$debug` through to `executeProgram()`, the same way the parent does.

It also guards the `hw.cpufrequency` / `hw.busfrequency` divisions in `cpuinfo()` with `is_numeric()`: those sysctl keys do not exist on Apple Silicon Macs, so `grabkey()` returns an empty string and PHP 8 raises `TypeError: Unsupported operand types: string / int`.

Tested on macOS 26.5 (Apple Silicon) with PHP 8.5: with these two changes the full dashboard renders again (CPU, memory, network, processes).

### Types of changes ###
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Code Preparation ###
- [x] Check for unused code
- [x] No unrelated changes are included
- [x] None of the changed files are reformatting only
- [x] Code is self explanatory or documented
- [x] All written text is properly translated (english language)

🤖 Generated with [Claude Code](https://claude.com/claude-code)